### PR TITLE
Re-level bibliography

### DIFF
--- a/ReseachProposal.Rmd
+++ b/ReseachProposal.Rmd
@@ -8,7 +8,7 @@ output:
     number_sections: yes
     toc: true
     toc_depth: 2
-  bibliography: 
+bibliography: 
   - bibliography.bib
 ---
 


### PR DESCRIPTION
Remember that YAML maintains hierarchy with tabs. `bibliography` isn't a sub-item of `output`, but its own top level item.
